### PR TITLE
Fix recording corrected values

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require "bundler/gem_tasks"
 require "rake/extensiontask"
 require 'rake/testtask'
-task :default => :spec
+task :default => :test
 Rake::ExtensionTask.new 'ruby_hdr_histogram'
 
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,11 @@
 require "bundler/gem_tasks"
 require "rake/extensiontask"
+require 'rake/testtask'
 task :default => :spec
 Rake::ExtensionTask.new 'ruby_hdr_histogram'
 
+
+Rake::TestTask.new do |t|
+    t.libs << "test"
+    t.pattern = "test/*_test.rb"
+end

--- a/lib/HDRHistogram.rb
+++ b/lib/HDRHistogram.rb
@@ -6,12 +6,12 @@ class HDRHistogram
     @multiplier = opt[:multiplier] || 1
     @unit = opt[:unit] || opt[:units]
   end
-  
+
   def record(val)
     raw_record(val * 1/@multiplier)
   end
-  def record_corrected(val)
-    raw_record_corrected(val * 1/@multiplier)
+  def record_corrected(val, expected_interval)
+    raw_record_corrected(val * 1/@multiplier, expected_interval * 1/@multiplier)
   end
   def min
     raw_min * @multiplier

--- a/test/HDRHistogram_test.rb
+++ b/test/HDRHistogram_test.rb
@@ -5,6 +5,21 @@ class HDRHistogramTest < Minitest::Test
     refute_nil ::HDRHistogram::VERSION
   end
 
+  def test_hrd_correct_record
+    hdr = HDRHistogram.new(0.001,1000, 3, multiplier: 0.001)
+    successful_responses = 1000
+    expected_time = 0.01
+
+    successful_responses.times { hdr.record(expected_time) }
+    hdr.record_corrected((successful_responses * expected_time), expected_time)
+    assert_equal hdr.percentile(10), 0.01
+    assert_equal hdr.percentile(50), 0.01
+    assert_equal hdr.percentile(75), 5.003
+    assert_equal hdr.percentile(90), 8.003
+    assert_equal hdr.percentile(99), 9.807
+    assert_equal hdr.percentile(100), 10.007
+  end
+
   def test_hdr
 
   end

--- a/test/HDRHistogram_test.rb
+++ b/test/HDRHistogram_test.rb
@@ -1,3 +1,5 @@
+require "test_helper"
+
 class HDRHistogramTest < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::HDRHistogram::VERSION


### PR DESCRIPTION
I was trying out the HDRHistogram when I noticed that `record_corrected` had the wrong number of parameters.  I fixed `record_corrected` and added a test for the functionality.

Additionally I modified rake to have a `test` task and to have the `test` task be the default task. I did this because the `rake spec` command did not work when I cloned the project to my machine.

If you don't want to change the rake commands I'd be happy to remove those commits.